### PR TITLE
#求人タイルの大きさをもう少し大きくして。#一列に表示する求人タイルの数を最大２枚にして。#求人票の写真のサイズをもう少し大きくして。写真の横幅は、求人タイルの横幅の*0.85の大きさで。...

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -11,12 +11,12 @@ export default function Home() {
       className={`flex flex-col items-center justify-between min-h-screen p-24 ${inter.className}`}
     >
       <h1 className="font-bold text-4xl">Job Postings</h1>
-      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
+      <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-2 lg:grid-cols-2">
         {/* Replace this with actual job data */}
         {Array(10).fill(null).map((_, index) => (
           <Link href={`/job/${index + 1}`} key={index}>
-            <a className="flex flex-col items-center border rounded shadow p-4">
-              <Image src="/path/to/image.jpg" alt="Job Image" width={100} height={75} />
+            <a className="flex flex-col items-center border rounded shadow p-6">
+              <Image src="/path/to/image.jpg" alt="Job Image" width={340} height={255} />
               <h2 className="font-bold text-xl mt-4">JOB TITLE {index + 1}</h2>
               <p className="mt-2">Job Type: Long-term Internship</p>
               <div className="flex items-center mt-2">


### PR DESCRIPTION
#求人タイルの大きさをもう少し大きくして。#一列に表示する求人タイルの数を最大２枚にして。#求人票の写真のサイズをもう少し大きくして。写真の横幅は、求人タイルの横幅の*0.85の大きさで。